### PR TITLE
Added example of form with itemtype 'set' + submission example

### DIFF
--- a/index.adoc
+++ b/index.adoc
@@ -613,7 +613,8 @@ A non-normative example
       "name": "friends", "type": "object", "form": {
         "type": "set", "itemtype": "object",
         "value": [
-          { "name": "firstName" }, { "name": "email" }
+          { "name": "firstName" },
+          { "name": "email" }
         ]
       }
     }

--- a/index.adoc
+++ b/index.adoc
@@ -837,7 +837,7 @@ Use of this member is OPTIONAL.
 
 ==== `required`
 
-The `required` member indicates whether or not the field value may equal `null` before is submitted to the form's linked resource location.
+The `required` member indicates whether or not the field value may equal `null` before it is submitted to the form's linked resource location.
 
 The `required` member is a boolean; it must equal either `true` or `false`. `null` or any other JSON value MUST NOT be specified.
 

--- a/index.adoc
+++ b/index.adoc
@@ -602,6 +602,37 @@ MUST NOT perform type validation on any value in the array before submitting the
 
 Use of this member is OPTIONAL.
 
+A non-normative example
+
+[source,json]
+----
+{
+  "href": "https://example.io/persons", "rel": ["create-form"], "method": "POST",
+  "value": [
+    {
+      "name": "friends", "type": "object", "form": {
+        "type": "set", "itemtype": "object",
+        "value": [
+          { "name": "firstName" }, { "name": "email" }
+        ]
+      }
+    }
+  ]
+}
+----
+
+.Example form submission object (corresponding to previous form example)
+
+[source,json]
+----
+{
+  "friends": [
+    {"firstName": "Peter", "email": "peter@example.com"},
+    {"firstName": "Laura", "email": "laura@example.com"}
+  ]
+}
+----
+
 ==== `label`
 
 The `label` member is a human-readable string that may be used to enhance usability.


### PR DESCRIPTION
I missed an example with itemtype in a form when I read the spec so here it is. Let me know if you think it is the right place or if it should be put somewhere else.